### PR TITLE
Prevent execution as different User and more..

### DIFF
--- a/grommunio-index-run.sh
+++ b/grommunio-index-run.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-
+if ! test $USER = "groweb"; then echo "Please run ${BASH_SOURCE[0]} as user 'groweb' or use the preferred way 'systemctl start grommunio-index.service' instead."; exit 1; fi
 MYSQL_CFG="/etc/gromox/mysql_adaptor.cfg"
 
-if [ ! -e "${MYSQL_CFG}" ] ; then
-  echo "MySQL configuration not found. ($MYSQL_CFG)"
+if [ ! -r "${MYSQL_CFG}" ] ; then
+  echo "MySQL configuration not found or readable by $USER. ($MYSQL_CFG)"
   exit 1
 fi
 
@@ -17,7 +17,7 @@ mysql_query='select username, maildir from users where id <> 0 and maildir <> ""
 mysql_cmd="mysql ${mysql_params} ${mysql_username} ${mysql_password} ${mysql_host} ${mysql_port} ${mysql_dbname}"
 web_index_path="/var/lib/grommunio-web/sqlite-index"
 
-echo "${mysql_query[@]}" | ${mysql_cmd} | while read -r username maildir ; do
+echo "${mysql_query}" | ${mysql_cmd} | while read -r username maildir ; do
   [ -e "${web_index_path}/${username}/" ] || mkdir "${web_index_path}/${username}/"
   grommunio-index "$maildir" -o "$web_index_path/$username/index.sqlite3"
 done


### PR DESCRIPTION
With the changes from 6a0f73a the manual execution of `grommunio-index-run.sh` as `UID=0` will result in wrong permissions in `/var/lib/grommunio-web/sqlite-index/**`.

After further testing i also ran into the issues with the Folder/File `/etc/gromox/adaptor.cfg` without any "world-readable" permissions. If i for instance have the following scenario
```
# ls -ld /etc/gromox /etc/gromox/adaptor.cfg
drwxrwx--- 2 grommunio gromox 4096 Dec 18 18:14 /etc/gromox
-rwxrwx--- 1 grommunio gromox  123 Nov  4 12:35 /etc/gromox/adaptor.cfg
```
it is maybe advisable to make use of `SupplementaryGroups=gromox`/`systemd.exec(5)`?

With those permissions we would need something like this to execute it manually..
```
su --user groweb --group groweb --supp-group gromox --shell /bin/bash --command /usr/sbin/grommunio-index-run.sh
```
And to be thorough as i already tried it here my current .override.
```
# /etc/systemd/system/grommunio-index.service.d/override.conf
[Service]
Group=groweb
SupplementaryGroups=gromox
SupplementaryGroups=grommunio
```

I used the "Group=" because i wasn't fully sure if the behaviour would be similiar to `su groweb -G gromox -c ...` which basically sets the runtime-group as "gromox" which we also not want...


cheers!