### PR TITLE
allow password with white spaces

### DIFF
--- a/grommunio-index-run.sh
+++ b/grommunio-index-run.sh
@@ -18,7 +18,7 @@ mysql_username=$(sed -ne 's/^mysql_username\s*=\s*\(.*\)/-u\1/p' ${MYSQL_CFG})
 if [ -z "$mysql_username" ]; then
 	mysql_username="-uroot"
 fi
-mysql_password=$(sed -ne 's/^mysql_password\s*=\s*\(.*\)/-p\1/p' ${MYSQL_CFG})
+mysql_password=$(sed -ne 's/^mysql_password\s*=\s*\(.*\)/\1/p' ${MYSQL_CFG})
 mysql_dbname=$(sed -ne 's/^mysql_dbname\s*=\s*\(.*\)/\1/p' ${MYSQL_CFG})
 if [ -z "$mysql_dbname" ]; then
 	mysql_dbname="email"
@@ -30,14 +30,13 @@ fi
 mysql_host=$(sed -ne 's/^mysql_host\s*=\s*\(.*\)/-h\1/p' ${MYSQL_CFG})
 mysql_port=$(sed -ne 's/^mysql_port\s*=\s*\(.*\)/-P\1/p' ${MYSQL_CFG})
 mysql_query='select username, maildir from users where id <> 0 and maildir <> "";'
-mysql_cmd="mysql ${mysql_params} ${mysql_username} ${mysql_password} ${mysql_host} ${mysql_port} ${mysql_dbname}"
 web_index_path="/var/lib/grommunio-web/sqlite-index"
 
 # This is hot garbage. If mysql for any reason rejects parameters and
 # manages outputs its help text, it does so to stdout and everything
 # goes down the drain.
 #
-echo "${mysql_query[@]}" | ${mysql_cmd} | while read -r username maildir ; do
+echo "${mysql_query}" | mysql ${mysql_params} ${mysql_username} -p"${mysql_password}" ${mysql_host} ${mysql_port} ${mysql_dbname} | while read -r username maildir ; do
 	if [ "${username:0:1}" = "-" ]; then
 		exit 1
 	fi


### PR DESCRIPTION
Hi there,

I had some problems with the search index and this is the only solution which was working with a mysql password including white spaces. Otherwise the mysql_cmd is returning the help of mysql, because it's called with the wrong arguments. Then the indexer tries to read every line of the output, which is just the help of the mysql command...

I hope this helps.