### PR TITLE
index-run: switch from su(1) to runuser(1)

### DIFF
--- a/grommunio-index-run.sh
+++ b/grommunio-index-run.sh
@@ -2,7 +2,7 @@
 
 umask 07
 if [ "$(id -u)" = 0 ]; then
-	exec su --group groweb --supp-group gromox --shell "$0" grommunio --
+	exec runuser --group groweb --supp-group gromox --shell "$0" grommunio --
 	exit 1
 fi
 


### PR DESCRIPTION
As per https://github.com/grommunio/grommunio-sync/commit/3abbea741fc8aec0a3802258b9d9d649e9b3b6d5, `grommunio-sync-top` uses `runuser` instead of `su`, apply same behaviour here, too.